### PR TITLE
Feat/repro the issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bazel-*
+MODULE.bazel.lock

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files(["some_data/dog.yaml"])
+
+filegroup(
+    name = "some_data",
+    data = glob(["some_data/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "bazel-example-data-label-list-runfiles",
+    version = "0.0.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+# bazel run @buildifier_prebuilt//:buildifier -- -v -r $(pwd)
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # bazel-example-data-label-list-runfiles
+
 Example of the run files in a file group not propagating through run files in a label_list
+
+## What are we working with
+
+Our required data is represented in two ways:
+ - a filegroup(name="//:some_data")
+ - the file directly, at //:some_data/dog.yaml
+
+The file we need to use in the rule that this error represents is the "dog.yaml".
+
+.. because dogs are good to find, of course.
+
+There are three targets that show this:
+
+1.  //check:check-succeeds -- with a file as data -- shows the successful mapping of runfiles to
+    include a source file. 'bazel run //check:check-succeeds' won't pass nor fail where bazel can
+    see, but will show an output of the "find" command that shows the precious "dog.yaml".  
+
+2.  //check:check-fails -- with a filegroup() as data -- shows how runfiles doesn't propagate
+    through the filegroup, so it's not there during the 'bazel run', so the "find" in the bash
+    script doesn't find it.  'bazel run //check:check-fails' won't pass nor fail where bazel can
+    see, but will show an output where the "dog.yaml" isn't visible.
+
+3.  //check:check-repaired -- with check-fails wrapped in a sh_binary() -- shows how sh_binary()
+    appends the correct runfiles to the returned DefaultInfo: the "find" sees "some_data/dog.yaml"
+
+## So what
+
+So..the issue is how to replicate the same benefit of the sh_binary() wrapper in the naked
+//check:check-fails
+
+This helps me resolve an issue in a larger ruleset that is really being a drag right now.  Total
+ballast thart I'd like to be past and drop in a completed form.  ...but dammit, it's not
+cooperating :) 

--- a/can_i_find.bzl
+++ b/can_i_find.bzl
@@ -1,0 +1,28 @@
+def _can_i_find_impl(ctx):
+    output_file = ctx.actions.declare_file(ctx.label.name + ".bash")
+
+    # https://github.com/bazelbuild/examples/blob/fdfabba6aa8065f5b1349931dc08678fdccdb678/rules/runfiles/complex_tool.bzl#L32
+    ctx.actions.write(
+        output = output_file,
+        is_executable = True,
+        content = r"""\
+set -x
+pwd
+find . -print
+exec test -f some_data/dog.yaml
+""",
+    )
+    # find . -name dog.yaml| grep dog ||  exit 1
+
+    return [DefaultInfo(
+        executable = output_file,
+        runfiles = ctx.runfiles(files = ctx.files.data),
+    )]
+
+can_i_find = rule(
+    implementation = _can_i_find_impl,
+    attrs = {
+        "data": attr.label_list(allow_files = True),
+    },
+    executable = True,
+)

--- a/check/BUILD.bazel
+++ b/check/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//:can_i_find.bzl", "can_i_find")
+
+can_i_find(
+    name = "check-succeeds",
+    data = ["//:some_data/dog.yaml"],  # data is a file
+)
+
+can_i_find(
+    name = "check-fails",
+    data = ["//:some_data"],  # data is a filegroup()
+)
+
+sh_binary(
+    name = "check-repaired",
+    srcs = [":check-fails"],
+    data = ["//:some_data"],  # data is a filegroup()
+)

--- a/some_data/dog.yaml
+++ b/some_data/dog.yaml
@@ -1,0 +1,2 @@
+cat: true
+mouse: false


### PR DESCRIPTION
This PR reproduces the issue:
- `bazel run //check:check-succeeds` succeeds (using single file as `data`)
- `bazel run //check:check-fails` fails (using a filegroup() as `data`)
- `bazel run //check:check-repaired` succeeds (wrapping `check-fails` in `sh_binary()`)

The difference in these runs (succeed/fail) is whether this data item is found:


```
++ find . -print
.
./some_data
./some_data/dog.yaml       <--  THIS ONE
./check
./check/check-succeeds.bash
++ exec test -f some_data/dog.yaml
```