### PR TITLE
fix: "collect_default" to repair the missing runfiles

### DIFF
--- a/can_i_find.bzl
+++ b/can_i_find.bzl
@@ -1,7 +1,6 @@
 def _can_i_find_impl(ctx):
     output_file = ctx.actions.declare_file(ctx.label.name + ".bash")
 
-    # https://github.com/bazelbuild/examples/blob/fdfabba6aa8065f5b1349931dc08678fdccdb678/rules/runfiles/complex_tool.bzl#L32
     ctx.actions.write(
         output = output_file,
         is_executable = True,
@@ -12,11 +11,18 @@ find . -print
 exec test -f some_data/dog.yaml
 """,
     )
-    # find . -name dog.yaml| grep dog ||  exit 1
+
+    transitive_files = []
+    for target in ctx.attr.data:
+        transitive_files.append(target[DefaultInfo].files)
+    files = depset(transitive = transitive_files)
 
     return [DefaultInfo(
         executable = output_file,
-        runfiles = ctx.runfiles(files = ctx.files.data),
+        runfiles = ctx.runfiles(files = ctx.files.data,
+            collect_default = True,  # <-- this is the key to including a filegroup() files in the runfiles
+            transitive_files = files,  # <-- ineffective to solve this problem but may be useful long-term
+        ),
     )]
 
 can_i_find = rule(


### PR DESCRIPTION
Apparently, the key is the `collect_default = True` given to `ctx.runfiles` -- although that's not the recommended method.

This repo can remain a canary for when that fails if I was to cause the checks to be actual unittests