### PR TITLE
feat: cause failure repro to actually fail unittests

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -1,0 +1,46 @@
+---
+name: Build
+env:
+  # Building on mac? Don't ever update homebrew: a huge cycles-consumer even if you ARE using it
+  HOMEBREW_NO_AUTO_UPDATE: 1
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+  push:
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]  # macos-latest
+    steps:
+      -
+        name: Date-Based Cache key
+        # get a key showing the current week (ISO: yyyyWww)
+        id: week
+        run: echo "::set-output name=iso::$(date +'bazel-%YW%U')"
+      -
+        uses: bazel-contrib/setup-bazel@0.9.0
+        with:
+          # Cache bazel downloads via bazelisk
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ steps.week.outputs.iso }}
+          # Share repository cache between workflows.
+          repository-cache: true
+      -
+        uses: actions/checkout@v4
+        # action runners have bazelisk: - uses: bazelbuild/setup-bazelisk@v2
+        # https://github.com/bazelbuild/bazel/issues/11062
+      -
+        run: bazel build //...
+      -
+        run: bazel test //... --test_output=errors --test_summary=detailed
+      -
+        run: bazel shutdown

--- a/check/BUILD.bazel
+++ b/check/BUILD.bazel
@@ -1,17 +1,42 @@
 load("//:can_i_find.bzl", "can_i_find")
 
+# Running this -- the `data` providing a direct source file -- the `some_data/dig.yaml` is present
+# in the `find` output, so this runfiles provides the mentioned file to the exec of the generated
+# script.
 can_i_find(
     name = "check-succeeds",
     data = ["//:some_data/dog.yaml"],  # data is a file
 )
 
+# Running this -- the `data` providing a direct source file indirectly through a filegroup() -- the
+# `some_data/dig.yaml` is NOT present in the `find` output, so this runfiles DOES NOT provide the
+# mentioned file to the exec of the generated script.
 can_i_find(
     name = "check-fails",
     data = ["//:some_data"],  # data is a filegroup()
 )
 
+# Running this -- a basic wrap of the failing test -- finds that the filegroup() dependency *IS*
+# properly propagated to the runfiles, DOES provide the required file to the environment of the
+# running script, passing the run.
 sh_binary(
     name = "check-repaired",
     srcs = [":check-fails"],
     data = ["//:some_data"],  # data is a filegroup()
+)
+
+# This test confirms that data file is found if used as a direct file in the label_list().  This
+# would start to fail if something broke in that construct.
+sh_test(
+    name = "recheck-succeeds",
+    srcs = [":check-succeeds"],
+)
+
+# This test confirms that data file is found if provided indirectly in a filegroup() in the
+# label_list().  This initially fails until the `collect_default = True` is added to the
+# `runfiles = ctx.runfiles()` call.  Since (IIRC) `collect_default` is a deprecated argument, it
+# may fail in future, so this test will canary that change so long as we keep up with updates.
+sh_test(
+    name = "recheck-fails",
+    srcs = [":check-fails"],
 )


### PR DESCRIPTION
This PR causes the repro of the failures in run files / dependency propagation to actually fail a unittest.

This causes any recurrence of the problem to show unittest failure, which can help auto merges to be held.